### PR TITLE
Fix action approach walks being interrupted or shortened

### DIFF
--- a/Source/Engine/Sheep/API/SheepAPI_Scene.cpp
+++ b/Source/Engine/Sheep/API/SheepAPI_Scene.cpp
@@ -383,7 +383,7 @@ shpvoid WalkTo(const std::string& actorName, const std::string& positionName)
     }
 
     // Ok, we can actually do the walk to it seems!
-    actor->WalkToExact(scenePosition->position, scenePosition->heading, AddWait());
+    actor->WalkToExact(scenePosition->position, scenePosition->heading, AddWait(), false);
     return 0;
 }
 RegFunc2(WalkTo, void, string, string, WAITABLE, REL_FUNC);

--- a/Source/GK3/Actions/ActionManager.h
+++ b/Source/GK3/Actions/ActionManager.h
@@ -61,8 +61,11 @@ public:
 
     void StartManualAction() { ++mManualActionCounter; }
     void FinishManualAction() { mManualActionCounter = Math::Max(--mManualActionCounter, 0); }
+    void StartActionApproach() { ++mActionApproachCounter; }
+    void FinishActionApproach() { mActionApproachCounter = Math::Max(--mActionApproachCounter, 0); }
 
-    bool IsActionPlaying() const { return mCurrentAction != nullptr || mManualActionCounter > 0; }
+    bool IsActionPlaying() const { return mCurrentAction != nullptr || mManualActionCounter > 0 || mActionApproachCounter > 0; }
+    bool IsNvcActionPlaying() const { return mCurrentAction != nullptr || mActionApproachCounter > 0; }
 
     void SkipCurrentAction() { mWantsActionSkip = true; }
     bool IsSkippingCurrentAction() const { return mWantsActionSkip || mSkipInProgress; }
@@ -157,6 +160,7 @@ private:
     // In addition to playing actual actions, we can also record "manual" actions that the game is performing.
     // This allows most of the game to behave as though we're waiting on an action, even though it might not actually be happening through the Action system.
     int mManualActionCounter = 0;
+    int mActionApproachCounter = 0;
 
     // A callback to execute when the current action finishes executing.
     std::function<void(const Action*)> mCurrentActionFinishCallback = nullptr;

--- a/Source/GK3/Actors/GKActor.cpp
+++ b/Source/GK3/Actors/GKActor.cpp
@@ -283,10 +283,10 @@ void GKActor::WalkToBestEffort(const Vector3& position, const Heading& heading, 
     });
 }
 
-void GKActor::WalkToExact(const Vector3& position, const Heading& heading, const std::function<void()>& finishCallback)
+void GKActor::WalkToExact(const Vector3& position, const Heading& heading, const std::function<void()>& finishCallback, bool allowFrustumPathSkip)
 {
-    InterruptFidget(false, [this, position, heading, finishCallback](){
-        mWalker->WalkToExact(position, heading, finishCallback);
+    InterruptFidget(false, [this, position, heading, finishCallback, allowFrustumPathSkip](){
+        mWalker->WalkToExact(position, heading, finishCallback, allowFrustumPathSkip);
     });
 }
 
@@ -388,7 +388,7 @@ void GKActor::WalkToAnimationStart(Animation* anim, const std::function<void()>&
 
     // Walk to that position/heading.
     InterruptFidget(false, [this, walkPos, heading, finishCallback](){
-        mWalker->WalkToExact(walkPos, heading, finishCallback);
+        mWalker->WalkToExact(walkPos, heading, finishCallback, false);
     });
 
     // To visualize walk position/heading.

--- a/Source/GK3/Actors/GKActor.h
+++ b/Source/GK3/Actors/GKActor.h
@@ -60,7 +60,7 @@ public:
     // Walker
     void TurnTo(const Heading& heading, const std::function<void()>& finishCallback);
     void WalkToBestEffort(const Vector3& position, const Heading& heading, const std::function<void()>& finishCallback);
-    void WalkToExact(const Vector3& position, const Heading& heading, const std::function<void()>& finishCallback);
+    void WalkToExact(const Vector3& position, const Heading& heading, const std::function<void()>& finishCallback, bool allowFrustumPathSkip = true);
     void WalkToGas(const Vector3& position, const Heading& heading, const std::function<void()>& finishCallback);
     void WalkToSee(GKObject* target, const std::function<void()>& finishCallback);
     void WalkToAnimationStart(Animation* anim, const std::function<void()>& finishCallback);

--- a/Source/GK3/Actors/Walker.cpp
+++ b/Source/GK3/Actors/Walker.cpp
@@ -84,11 +84,11 @@ void Walker::WalkToBestEffort(const Vector3& position, const Heading& heading, c
     WalkToInternal(position, heading, finishCallback, false, false);
 }
 
-void Walker::WalkToExact(const Vector3& position, const Heading& heading, const std::function<void()>& finishCallback)
+void Walker::WalkToExact(const Vector3& position, const Heading& heading, const std::function<void()>& finishCallback, bool allowFrustumPathSkip)
 {
     // This is "exact", which means it will always leave the walker at the exact position/heading specified.
     // This version is used for specific ScenePositions, or when scripts demand a specific walk pos internally.
-    WalkToInternal(position, heading, finishCallback, false, true);
+    WalkToInternal(position, heading, finishCallback, false, true, allowFrustumPathSkip);
 }
 
 void Walker::WalkToGas(const Vector3& position, const Heading& heading, const std::function<void()>& finishCallback)
@@ -480,10 +480,13 @@ void Walker::OnUpdate(float deltaTime)
     }
 }
 
-void Walker::WalkToInternal(const Vector3& position, const Heading& heading, const std::function<void()>& finishCallback, bool fromAutoscript, bool mustReachDestination)
+void Walker::WalkToInternal(const Vector3& position, const Heading& heading, const std::function<void()>& finishCallback, bool fromAutoscript, bool mustReachDestination, bool allowFrustumPathSkip)
 {
     // Save if from autoscript.
     mFromAutoscript = fromAutoscript;
+
+    // Save whether frustum path skipping is allowed for this walk.
+    mAllowFrustumPathSkip = allowFrustumPathSkip;
 
     // Save finish callback.
     mFinishedPathCallback = finishCallback;
@@ -1026,7 +1029,7 @@ int Walker::FindEarliestPathNodeInsideActiveTriggerRegion(Vector3& outEnterTrigg
     int earliestPathIndex = -1;
 
     // This logic only applies to the Ego in the current scene when walking freely (not during an action).
-    if(mGKOwner == gSceneManager.GetScene()->GetEgo() && !gActionManager.IsActionPlaying())
+    if(mGKOwner == gSceneManager.GetScene()->GetEgo() && !gActionManager.IsNvcActionPlaying())
     {
         // Iterate all triggers in the scene - this is often zero. Scenes rarely have trigger regions.
         for(auto& trigger : gSceneManager.GetScene()->GetSceneData()->GetTriggers())
@@ -1082,8 +1085,8 @@ bool Walker::SkipPathNodesOutsideFrustum()
     // But if 90% of the path is behind the camera, the walker can just skip to the node right before the camera and walk from there!
 
     // Skipping path nodes outside the view frustum is mainly meant for user-initiated walk actions.
-    // Don't do this for AI walkers (autoscript), of if this isn't ego.
-    if(mFromAutoscript || mGKOwner != gSceneManager.GetScene()->GetEgo() || mPath.empty())
+    // Don't do this for AI walkers (autoscript), action approach walks, or if this isn't ego.
+    if(mFromAutoscript || mGKOwner != gSceneManager.GetScene()->GetEgo() || mPath.empty() || !mAllowFrustumPathSkip)
     {
         //printf("Early out skip path nodes - not ego, from autoscript, or path is empty.\n");
         return false;

--- a/Source/GK3/Actors/Walker.h
+++ b/Source/GK3/Actors/Walker.h
@@ -38,7 +38,7 @@ public:
                       Animation* startTurnLeftAnim, Animation* startTurnRightAnim);
 
     void WalkToBestEffort(const Vector3& position, const Heading& heading, const std::function<void()>& finishCallback);
-    void WalkToExact(const Vector3& position, const Heading& heading, const std::function<void()>& finishCallback);
+    void WalkToExact(const Vector3& position, const Heading& heading, const std::function<void()>& finishCallback, bool allowFrustumPathSkip = true);
     void WalkToGas(const Vector3& position, const Heading& heading, const std::function<void()>& finishCallback);
     void WalkToSee(GKObject* target, const std::function<void()>& finishCallback);
 
@@ -140,12 +140,15 @@ private:
     // Only use case is the demon in the final fight so far.
     bool mAllowWalkSkip = true;
 
+    // If false, the walker must follow the full path (e.g. when walking to an animation start pose).
+    bool mAllowFrustumPathSkip = true;
+
     // REGION SUPPORT
     // A callback for exiting a region.
     int mExitRegionIndex = -1;
     std::function<void()> mExitRegionCallback = nullptr;
 
-    void WalkToInternal(const Vector3& position, const Heading& heading, const std::function<void()>& finishCallback, bool fromAutoscript, bool mustReachDestination);
+    void WalkToInternal(const Vector3& position, const Heading& heading, const std::function<void()>& finishCallback, bool fromAutoscript, bool mustReachDestination, bool allowFrustumPathSkip = true);
 
     void PopAndNextAction();
     void NextAction();

--- a/Source/GK3/Scene/Scene.cpp
+++ b/Source/GK3/Scene/Scene.cpp
@@ -1390,6 +1390,17 @@ void Scene::ExecuteAction(const Action* action)
     // Log to "Actions" stream.
     gReportManager.Log("Actions", "Playing NVC " + action->ToString());
 
+    gActionManager.StartActionApproach();
+
+    // Clear the pending approach before handing off to Sheep/NVC execution.
+    auto finishApproachAndExecute = [action]() {
+        gActionManager.FinishActionApproach();
+        if(!gActionManager.IsActionBarShowing())
+        {
+            gActionManager.ExecuteAction(action, nullptr, false);
+        }
+    };
+
     // Before executing the NVC, we need to handle any approach.
     switch(action->approach)
     {
@@ -1399,16 +1410,11 @@ void Scene::ExecuteAction(const Action* action)
             if(scenePos != nullptr)
             {
                 //Debug::DrawLine(mEgo->GetPosition(), scenePos->position, Color32::Green, 60.0f);
-                mEgo->WalkToExact(scenePos->position, scenePos->heading, [action]() {
-                    if(!gActionManager.IsActionBarShowing())
-                    {
-                        gActionManager.ExecuteAction(action, nullptr, false);
-                    }
-                });
+                mEgo->WalkToExact(scenePos->position, scenePos->heading, finishApproachAndExecute);
             }
             else
             {
-                gActionManager.ExecuteAction(action, nullptr, false);
+                finishApproachAndExecute();
             }
             break;
         }
@@ -1417,23 +1423,18 @@ void Scene::ExecuteAction(const Action* action)
             Animation* anim = gAssetManager.LoadAsset<Animation>(action->target, AssetScope::Scene);
             if(anim != nullptr)
             {
-                mEgo->WalkToAnimationStart(anim, [action]() {
-                    if(!gActionManager.IsActionBarShowing())
-                    {
-                        gActionManager.ExecuteAction(action, nullptr, false);
-                    }
-                });
+                mEgo->WalkToAnimationStart(anim, finishApproachAndExecute);
             }
             else
             {
-                gActionManager.ExecuteAction(action, nullptr, false);
+                finishApproachAndExecute();
             }
             break;
         }
         case Action::Approach::Near: // Never used in GK3.
         {
             LOG_WARNING("Executed NEAR approach type! This is unexpected!");
-            gActionManager.ExecuteAction(action, nullptr, false);
+            finishApproachAndExecute();
             break;
         }
         case Action::Approach::NearModel: // Example use: RC1 Bookstore Door, Hallway R25 Door
@@ -1456,28 +1457,23 @@ void Scene::ExecuteAction(const Action* action)
                 }
 
                 // Walk there, and then do the action.
-                mEgo->WalkToBestEffort(walkPos, walkHeading, [action](){
-                    if(!gActionManager.IsActionBarShowing())
-                    {
-                        gActionManager.ExecuteAction(action, nullptr, false);
-                    }
-                });
+                mEgo->WalkToBestEffort(walkPos, walkHeading, finishApproachAndExecute);
             }
             else
             {
                 // Just do the action if model could not be found.
-                gActionManager.ExecuteAction(action, nullptr, false);
+                finishApproachAndExecute();
             }
             break;
         }
         case Action::Approach::Region: // Never used in GK3 (it does appear once in a SIF file, but it is misconfigured with an invalid region anyway).
         {
-            gActionManager.ExecuteAction(action, nullptr, false);
+            finishApproachAndExecute();
             break;
         }
         case Action::Approach::TurnTo: // Never used in GK3.
         {
-            gActionManager.ExecuteAction(action, nullptr, false);
+            finishApproachAndExecute();
             break;
         }
         case Action::Approach::TurnToModel: // Example use: R25 Couch Sit, most B25
@@ -1504,12 +1500,7 @@ void Scene::ExecuteAction(const Action* action)
 
             // Do a "turn to" heading.
             Heading turnToHeading = Heading::FromDirection(egoToModel);
-            mEgo->TurnTo(turnToHeading, [action]() -> void {
-                if(!gActionManager.IsActionBarShowing())
-                {
-                    gActionManager.ExecuteAction(action, nullptr, false);
-                }
-            });
+            mEgo->TurnTo(turnToHeading, finishApproachAndExecute);
             break;
         }
         case Action::Approach::WalkToSee: // Example use: R25 Look Painting/Couch/Dresser/Plant, RC1 Look Bench/Bookstore Sign
@@ -1521,30 +1512,25 @@ void Scene::ExecuteAction(const Action* action)
             // If didn't find it, print a warning/error and just execute right away.
             if(obj != nullptr)
             {
-                mEgo->WalkToSee(obj, [action]() {
-                    if(!gActionManager.IsActionBarShowing())
-                    {
-                        gActionManager.ExecuteAction(action, nullptr, false);
-                    }
-                });
+                mEgo->WalkToSee(obj, finishApproachAndExecute);
             }
             else
             {
                 LOG_WARNING("Could not find WalkToSee target %s.", action->target.c_str());
-                gActionManager.ExecuteAction(action, nullptr, false);
+                finishApproachAndExecute();
             }
             break;
         }
         case Action::Approach::None:
         {
             // Just do it!
-            gActionManager.ExecuteAction(action, nullptr, false);
+            finishApproachAndExecute();
             break;
         }
         default:
         {
             gReportManager.Log("Error", "Invalid approach " + std::to_string(static_cast<int>(action->approach)));
-            gActionManager.ExecuteAction(action, nullptr, false);
+            finishApproachAndExecute();
             break;
         }
     }


### PR DESCRIPTION
## Summary

Fixes scripted action approach walks being incorrectly interrupted, shortened, or path-skipped before the associated NVC action begins.

Covers Issue #51 and #72 

### Changes

* Track the action approach phase so pre-NVC walks are not treated as active NVC actions.
* Prevent trigger regions and `SkipToView` from interrupting walks during an action approach.
* Only allow trigger-shortening while an actual NVC action script is running, not during manual/pre-action interruptions.
* Prevent frustum path skipping from incorrectly shortening or bypassing action approach paths.
* Update `GKActor` walk-to-animation handling so the approach walk is completed before starting the associated animation/action.

### Result

Action approach walks now complete as intended without being prematurely shortened or interrupted by trigger handling, `SkipToView`, or frustum path optimization, while preserving the existing interruption behavior once the actual NVC action has started.
